### PR TITLE
Added option to use absolute expiration

### DIFF
--- a/src/OutputCacheActionFilter.cs
+++ b/src/OutputCacheActionFilter.cs
@@ -45,6 +45,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// Comma separated list of query string parameters to vary the caching by.
         /// </summary>
         public string VaryByParam { get; set; }
+                
+        /// <summary>
+        /// Use absolute expiration instead of the default sliding expiration.
+        /// </summary>
+        public bool UseAbsoluteExpiration { get; set; }
 
         /// <summary>
         /// Executing the filter
@@ -69,7 +74,8 @@ namespace Microsoft.AspNetCore.Mvc
                     slidingExpiration: TimeSpan.FromSeconds(Duration),
                     varyByHeaders: VaryByHeader,
                     varyByParam: VaryByParam,
-                    fileDependencies: _fileDependencies
+                    fileDependencies: _fileDependencies,
+                    useAbsoluteExpiration: UseAbsoluteExpiration
                 );
             }
         }

--- a/src/OutputCacheFeatureExtensions.cs
+++ b/src/OutputCacheFeatureExtensions.cs
@@ -20,8 +20,9 @@ namespace WebEssentials.AspNetCore.OutputCaching
             string varyByHeader = profile.VaryByHeader;
             string varyByParam = profile.VaryByParam;
             string[] fileDependencies = profile.FileDependencies.ToArray();
+            bool useAbsoluteExpiration = profile.UseAbsoluteExpiration;
 
-            context.EnableOutputCaching(slidingExpiration, varyByHeader, varyByParam, fileDependencies);
+            context.EnableOutputCaching(slidingExpiration, varyByHeader, varyByParam, useAbsoluteExpiration, fileDependencies);
         }
 
         /// <summary>
@@ -31,8 +32,9 @@ namespace WebEssentials.AspNetCore.OutputCaching
         /// <param name="slidingExpiration">The amount of seconds to cache the output for.</param>
         /// <param name="varyByHeaders">Comma separated list of HTTP headers to vary the caching by.</param>
         /// <param name="varyByParam">Comma separated list of query string parameter names to vary the caching by.</param>
+        /// <param name="useAbsoluteExpiration">Use absolute expiration instead of the default sliding expiration.</param>
         /// <param name="fileDependencies">Globbing patterns</param>
-        public static void EnableOutputCaching(this HttpContext context, TimeSpan slidingExpiration, string varyByHeaders = null, string varyByParam = null, params string[] fileDependencies)
+        public static void EnableOutputCaching(this HttpContext context, TimeSpan slidingExpiration, string varyByHeaders = null, string varyByParam = null, bool useAbsoluteExpiration = false, params string[] fileDependencies)
         {
             OutputCacheProfile feature = context.Features.Get<OutputCacheProfile>();
 
@@ -46,6 +48,7 @@ namespace WebEssentials.AspNetCore.OutputCaching
             feature.FileDependencies = fileDependencies;
             feature.VaryByHeader = varyByHeaders;
             feature.VaryByParam = varyByParam;
+            feature.UseAbsoluteExpiration = useAbsoluteExpiration;
         }
 
         internal static bool IsOutputCachingEnabled(this HttpContext context, out OutputCacheProfile profile)

--- a/src/OutputCacheProfile.cs
+++ b/src/OutputCacheProfile.cs
@@ -27,5 +27,11 @@ namespace WebEssentials.AspNetCore.OutputCaching
         /// Globbing patterns relative to the content root (not the wwwroot).
         /// </summary>
         public IEnumerable<string> FileDependencies { get; set; } = new[] { "**/*.*" };
+
+        /// <summary>
+        /// Use absolute expiration instead of the default sliding expiration.
+        /// </summary>
+        public bool UseAbsoluteExpiration { get; set; }
+
     }
 }

--- a/src/OutputCacheService.cs
+++ b/src/OutputCacheService.cs
@@ -28,7 +28,14 @@ namespace WebEssentials.AspNetCore.OutputCaching
             var env = (IHostingEnvironment)context.RequestServices.GetService(typeof(IHostingEnvironment));
 
             var options = new MemoryCacheEntryOptions();
-            options.SetSlidingExpiration(TimeSpan.FromSeconds(profile.Duration));
+            if (profile.UseAbsoluteExpiration)
+            {
+                options.SetAbsoluteExpiration(TimeSpan.FromSeconds(profile.Duration));
+            }
+            else
+            {
+                options.SetSlidingExpiration(TimeSpan.FromSeconds(profile.Duration));
+            }
 
             foreach (string globs in profile.FileDependencies)
             {


### PR DESCRIPTION
As @markheath mentioned in #4 it is not possible to use absolute expiration which can be a deal breaker if your site/api has semi-regular traffic to it.
I added the option to make the expiration absolute so that the cache item is expired after the set amount of seconds regardless of whether or not it is fetched.

The addition is 100% backwards compatible and does not change any implementations already in place.