### PR TITLE
Added VaryByCustom option for caching.

### DIFF
--- a/WebEssentials.AspNetCore.OutputCaching.sln
+++ b/WebEssentials.AspNetCore.OutputCaching.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample\Sample.csproj", "{0E9FD975-4138-445C-A2D4-EB9874C80B26}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "sample\Sample.csproj", "{0E9FD975-4138-445C-A2D4-EB9874C80B26}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/sample/Controllers/HomeController.cs
+++ b/sample/Controllers/HomeController.cs
@@ -26,6 +26,12 @@ namespace Sample.Controllers
             return View("Index");
         }
 
+        [OutputCache(VaryByCustom = "foo")]
+        public IActionResult Custom()
+        {
+            return View("Index");
+        }
+
         [OutputCache(Profile = "default")]
         public IActionResult Profile()
         {

--- a/sample/OuputCacheVaryByCustomService.cs
+++ b/sample/OuputCacheVaryByCustomService.cs
@@ -1,0 +1,19 @@
+using WebEssentials.AspNetCore.OutputCaching;
+
+namespace Sample
+{
+    public class OuputCacheVaryByCustomService : IOutputCacheVaryByCustomService
+    {
+        public string GetVaryByCustomString(string arg)
+        {
+            if (arg == "foo")
+            {
+                return "bar";
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -22,6 +22,7 @@ namespace Sample
                     FileDependencies= new []{ ""}
                 };
             });
+            services.AddTransient<IOutputCacheVaryByCustomService, OuputCacheVaryByCustomService>();
 
             services.AddWebMarkupMin(options =>
             {

--- a/src/IOutputCacheVaryByCustomService.cs
+++ b/src/IOutputCacheVaryByCustomService.cs
@@ -2,8 +2,16 @@ using System.Threading.Tasks;
 
 namespace WebEssentials.AspNetCore.OutputCaching
 {
+    /// <summary>
+    /// An interface for a service to get the VaryByCustom string.
+    /// </summary>
     public interface IOutputCacheVaryByCustomService
     {
+        /// <summary>
+        /// A function that takes an argument and returns a string to vary the caching by.
+        /// </summary>
+        /// <param name="arg">The argument to the VaryByCustom function.</param>
+        /// <returns>A string to vary the caching by.</returns>
         string GetVaryByCustomString(string arg);
     }
 }

--- a/src/IOutputCacheVaryByCustomService.cs
+++ b/src/IOutputCacheVaryByCustomService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace WebEssentials.AspNetCore.OutputCaching
+{
+    public interface IOutputCacheVaryByCustomService
+    {
+        string GetVaryByCustomString(string arg);
+    }
+}

--- a/src/OutputCacheActionFilter.cs
+++ b/src/OutputCacheActionFilter.cs
@@ -45,6 +45,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// Comma separated list of query string parameters to vary the caching by.
         /// </summary>
         public string VaryByParam { get; set; }
+
+        /// <summary>
+        /// Comma separated list of arguments to vary the caching by using a custom function.
+        /// </summary>
+        public string VaryByCustom { get; set; }
                 
         /// <summary>
         /// Use absolute expiration instead of the default sliding expiration.
@@ -74,6 +79,7 @@ namespace Microsoft.AspNetCore.Mvc
                     slidingExpiration: TimeSpan.FromSeconds(Duration),
                     varyByHeaders: VaryByHeader,
                     varyByParam: VaryByParam,
+                    varyByCustom: VaryByCustom,
                     fileDependencies: _fileDependencies,
                     useAbsoluteExpiration: UseAbsoluteExpiration
                 );

--- a/src/OutputCacheFeatureExtensions.cs
+++ b/src/OutputCacheFeatureExtensions.cs
@@ -19,10 +19,11 @@ namespace WebEssentials.AspNetCore.OutputCaching
             var slidingExpiration = TimeSpan.FromSeconds(profile.Duration);
             string varyByHeader = profile.VaryByHeader;
             string varyByParam = profile.VaryByParam;
+            string varyByCustom = profile.VaryByCustom;
             string[] fileDependencies = profile.FileDependencies.ToArray();
             bool useAbsoluteExpiration = profile.UseAbsoluteExpiration;
 
-            context.EnableOutputCaching(slidingExpiration, varyByHeader, varyByParam, useAbsoluteExpiration, fileDependencies);
+            context.EnableOutputCaching(slidingExpiration, varyByHeader, varyByParam, varyByCustom, useAbsoluteExpiration, fileDependencies);
         }
 
         /// <summary>
@@ -32,9 +33,10 @@ namespace WebEssentials.AspNetCore.OutputCaching
         /// <param name="slidingExpiration">The amount of seconds to cache the output for.</param>
         /// <param name="varyByHeaders">Comma separated list of HTTP headers to vary the caching by.</param>
         /// <param name="varyByParam">Comma separated list of query string parameter names to vary the caching by.</param>
+        /// <param name="varyByCustom">Comma separated list of arguments to vary the caching by using a custom function.</param>
         /// <param name="useAbsoluteExpiration">Use absolute expiration instead of the default sliding expiration.</param>
         /// <param name="fileDependencies">Globbing patterns</param>
-        public static void EnableOutputCaching(this HttpContext context, TimeSpan slidingExpiration, string varyByHeaders = null, string varyByParam = null, bool useAbsoluteExpiration = false, params string[] fileDependencies)
+        public static void EnableOutputCaching(this HttpContext context, TimeSpan slidingExpiration, string varyByHeaders = null, string varyByParam = null, string varyByCustom = null, bool useAbsoluteExpiration = false, params string[] fileDependencies)
         {
             OutputCacheProfile feature = context.Features.Get<OutputCacheProfile>();
 
@@ -48,6 +50,7 @@ namespace WebEssentials.AspNetCore.OutputCaching
             feature.FileDependencies = fileDependencies;
             feature.VaryByHeader = varyByHeaders;
             feature.VaryByParam = varyByParam;
+            feature.VaryByCustom = varyByCustom;
             feature.UseAbsoluteExpiration = useAbsoluteExpiration;
         }
 

--- a/src/OutputCacheProfile.cs
+++ b/src/OutputCacheProfile.cs
@@ -24,6 +24,11 @@ namespace WebEssentials.AspNetCore.OutputCaching
         public string VaryByParam { get; set; }
 
         /// <summary>
+        /// Comma separated list of arguments to vary the caching by using a custom function.
+        /// </summary>
+        public string VaryByCustom { get; set; }
+
+        /// <summary>
         /// Globbing patterns relative to the content root (not the wwwroot).
         /// </summary>
         public IEnumerable<string> FileDependencies { get; set; } = new[] { "**/*.*" };

--- a/src/OutputCacheResponseEntry.cs
+++ b/src/OutputCacheResponseEntry.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace WebEssentials.AspNetCore.OutputCaching
 {
@@ -56,6 +57,19 @@ namespace WebEssentials.AspNetCore.OutputCaching
                     if (context.Request.Headers.ContainsKey(header))
                     {
                         key += header + "=" + context.Request.Headers[header];
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(_profile.VaryByCustom))
+            {
+                var varyByCustomService = context.RequestServices.GetService<IOutputCacheVaryByCustomService>();
+
+                if (varyByCustomService != null)
+                {
+                    foreach (string argument in _profile.VaryByCustom.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        key += argument + "=" + varyByCustomService.GetVaryByCustomString(argument);
                     }
                 }
             }

--- a/src/WebEssentials.AspNetCore.OutputCaching.csproj
+++ b/src/WebEssentials.AspNetCore.OutputCaching.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
This adds a VaryByCustom option (similar to the old MVC) which allows you to customize how the caching is varied. For example, you can vary the cache based on whether the user is on desktop or mobile.

The advantage to using the service-based approach is that the `GetVaryByCustomString` function can depend on other services.