### PR TITLE
Allowed a custom file provider to be used for watching the file dependencies

### DIFF
--- a/src/OutputCacheFeatureExtensions.cs
+++ b/src/OutputCacheFeatureExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
 
 namespace WebEssentials.AspNetCore.OutputCaching
 {
@@ -22,8 +23,9 @@ namespace WebEssentials.AspNetCore.OutputCaching
             string varyByCustom = profile.VaryByCustom;
             string[] fileDependencies = profile.FileDependencies.ToArray();
             bool useAbsoluteExpiration = profile.UseAbsoluteExpiration;
+            IFileProvider fileProvider = profile.FileProvider;
 
-            context.EnableOutputCaching(slidingExpiration, varyByHeader, varyByParam, varyByCustom, useAbsoluteExpiration, fileDependencies);
+            context.EnableOutputCaching(slidingExpiration, varyByHeader, varyByParam, varyByCustom, useAbsoluteExpiration, fileProvider, fileDependencies);
         }
 
         /// <summary>
@@ -35,8 +37,9 @@ namespace WebEssentials.AspNetCore.OutputCaching
         /// <param name="varyByParam">Comma separated list of query string parameter names to vary the caching by.</param>
         /// <param name="varyByCustom">Comma separated list of arguments to vary the caching by using a custom function.</param>
         /// <param name="useAbsoluteExpiration">Use absolute expiration instead of the default sliding expiration.</param>
+        /// <param name="fileProvider">File provider to use for globbing patterns.</param>
         /// <param name="fileDependencies">Globbing patterns</param>
-        public static void EnableOutputCaching(this HttpContext context, TimeSpan slidingExpiration, string varyByHeaders = null, string varyByParam = null, string varyByCustom = null, bool useAbsoluteExpiration = false, params string[] fileDependencies)
+        public static void EnableOutputCaching(this HttpContext context, TimeSpan slidingExpiration, string varyByHeaders = null, string varyByParam = null, string varyByCustom = null, bool useAbsoluteExpiration = false, IFileProvider fileProvider = null, params string[] fileDependencies)
         {
             OutputCacheProfile feature = context.Features.Get<OutputCacheProfile>();
 
@@ -48,6 +51,7 @@ namespace WebEssentials.AspNetCore.OutputCaching
 
             feature.Duration = slidingExpiration.TotalSeconds;
             feature.FileDependencies = fileDependencies;
+            feature.FileProvider = fileProvider;
             feature.VaryByHeader = varyByHeaders;
             feature.VaryByParam = varyByParam;
             feature.VaryByCustom = varyByCustom;


### PR DESCRIPTION
This PR adds an `IFileProvider` to the `OutputCacheProfile`, which allows files outside the content root to be used as file dependencies.

This PR is needed to fix https://github.com/madskristensen/VsixGallery/issues/35