### PR TITLE
Fix for #32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 image: Visual Studio 2022
 version: 1.0.{build}
 
+install:
+  - choco install dotnet-10.0-sdk
+
 build_script:
   - dotnet restore -v quiet
   - ps: dotnet build /p:configuration=Release /p:Version=$($env:appveyor_build_version)

--- a/sample/Controllers/HomeController.cs
+++ b/sample/Controllers/HomeController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using System;
 using WebEssentials.AspNetCore.OutputCaching;
 using Microsoft.Net.Http.Headers;
-using Microsoft.AspNetCore.Http.Internal;
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;
 
@@ -54,13 +53,13 @@ namespace Sample.Controllers
         {
             var queryString = new Dictionary<string, StringValues>();
             queryString.Add("foo", new StringValues("1"));
-            var key = _outputCacheKeysProvider.GetRequestCacheKey(HttpContext, 
-                                                                  new OutputCacheProfile() { 
-                                                                      Duration = 600, 
-                                                                      VaryByParam = "foo", 
+            var key = _outputCacheKeysProvider.GetRequestCacheKey(HttpContext,
+                                                                  new OutputCacheProfile() {
+                                                                      Duration = 600,
+                                                                      VaryByParam = "foo",
                                                                       VaryByHeader = null,
                                                                       VaryByCustom = null
-                                                                  },  
+                                                                  },
                                                                   System.Net.WebRequestMethods.Http.Get,
                                                                   Url.Action("Query", "Home"),
                                                                   new QueryCollection(queryString)

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="WebMarkupMin.AspNetCore2">
-      <Version>2.4.2</Version>
-    </PackageReference>
+    <PackageReference Include="WebMarkupMin.AspNetCoreLatest" Version="2.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using WebEssentials.AspNetCore.OutputCaching;
-using WebMarkupMin.AspNetCore2;
+using WebMarkupMin.AspNetCoreLatest;
 
 namespace Sample
 {
@@ -13,7 +12,7 @@ namespace Sample
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc(options => options.EnableEndpointRouting = false);
             services.AddOutputCaching(options =>
             {
                 options.Profiles["default"] = new OutputCacheProfile
@@ -37,7 +36,6 @@ namespace Sample
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseBrowserLink();
             app.UseDeveloperExceptionPage();
 
             app.UseOutputCaching();

--- a/src/WebEssentials.AspNetCore.OutputCaching.csproj
+++ b/src/WebEssentials.AspNetCore.OutputCaching.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageTags>asp.net, performance, speed, cache, caching</PackageTags>
     <Version>1.0.0</Version>
@@ -22,7 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.9" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">


### PR DESCRIPTION
Fix for #32 by bumping "Microsoft.AspNetCore.Mvc" to version 2.3.9 and also adding explicit net8.0;net9.0;net10.0 as TargetFramework and other small changes to get it working in modern .net versions.

```
- added net8.0;net9.0;net10.0 as TargetFramework
- updated "Microsoft.AspNetCore.Mvc" to version 2.3.9
- added System.Text.RegularExpressions in Version 4.3.1 to netstandard2.0, as transitive version 4.3.0 has at least one vulnerability with high severity

- Sample:
  - added net8.0;net9.0;net10.0 as TargetFramework
  - replaced WebMarkupMin.AspNetCore2 with WebMarkupMin.AspNetCoreLatest
  - replaced services.AddMvc(); with services.AddMvc(options => options.EnableEndpointRouting = false);
  - removed "using Microsoft.AspNetCore.Http.Internal;" call as namespace is not found in modern .net versions
  - removed "app.UseBrowserLink();" as only working until ASP.NET Core 2.2
```